### PR TITLE
correção de loop infinito no retry do action do checkup

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,8 @@ Uma dependência pode ter os seguintes escopos:
 		- Informe no campo ***Script*** a ação a ser executada.
 		- Para remover uma ação, clique no botão ***Remove***. 
 	- Um checkup pode ser executado como uma pré-validação ou uma pós validação. Pré-validações ocorrem quando todas as dependências foram atendidas e imediatamente antes da execução do *job*, enquanto pós-validações ocorrem após a execução do *job*. Para definir o tipo de um checkup, clique no toggle e escolha entre ***Pre-validation*** e ***Post-validation***. 
-- Defina o número de tentativa de execução do *job* no campo ***Retries***. 
+- Defina o número de tentativas de execução do *job* no campo ***Retries***.
+> Para ações NOTHING e LOG_AND_CONTINUE não há número de tentativas.
 - Caso necessário, selecione um aprovador para o checkup no combo ***Approver***.
 - Clique no botão ***Save***.
 

--- a/src/main/java/br/com/dafiti/hanger/service/JobCheckupService.java
+++ b/src/main/java/br/com/dafiti/hanger/service/JobCheckupService.java
@@ -212,7 +212,7 @@ public class JobCheckupService {
                         log = checkup.getAction().equals(Action.LOG_AND_CONTINUE);
 
                         //Identifies if should execute something. 
-                        if (!validated && !log) {
+                        if (!validated) {
                             boolean commandResult = false;
 
                             //Executes the checkup command.

--- a/src/main/java/br/com/dafiti/hanger/service/JobCheckupService.java
+++ b/src/main/java/br/com/dafiti/hanger/service/JobCheckupService.java
@@ -176,7 +176,7 @@ public class JobCheckupService {
      */
     public boolean evaluate(Job job, boolean prevalidation, Scope scope) {
         boolean log;
-        boolean stop = false;
+        //boolean stop = false;
         boolean validated = true;
 
         //Identifies if the job has checkup.
@@ -200,7 +200,7 @@ public class JobCheckupService {
 
                 for (JobCheckup checkup : checkups) {
                     //Identify the query scope and if it is enabled. 
-                    if (checkup.isEnabled() && !stop) {
+                    if (checkup.isEnabled()) {
                         //Run the query. 
                         String value = this.executeQuery(checkup);
 
@@ -210,50 +210,48 @@ public class JobCheckupService {
                         //Identify if is just a log. 
                         log = checkup.getAction().equals(Action.LOG_AND_CONTINUE);
 
-                        //Identify if should retry.
-                        if (retry <= job.getRetry() || (retry == 1 && job.getRetry() == 0)) {
-                            JobCheckupLog jobCheckupLog = new JobCheckupLog(checkup);
+                        JobCheckupLog jobCheckupLog = new JobCheckupLog(checkup);
 
-                            //Identify if should execute something. 
-                            if (!validated && !log) {
-                                boolean commandResult = false;
+                        //Identify if should execute something. 
+                        if (!validated && !log) {
+                            boolean commandResult = false;
 
-                                //Execute the checkup command.
-                                for (Command command : checkup.getCommand()) {
-                                    commandResult = this.executeCommand(checkup, command, jobCheckupLog);
+                            //Execute the checkup command.
+                            for (Command command : checkup.getCommand()) {
+                                commandResult = this.executeCommand(checkup, command, jobCheckupLog);
 
-                                    if (!commandResult) {
-                                        break;
-                                    }
+                                if (!commandResult) {
+                                    break;
                                 }
-
-                                //Identify if should revalidate the checkup.
-                                if (commandResult) {
-                                    value = this.executeQuery(checkup);
-                                    validated = this.check(checkup, value);
-                                }
-
-                                //Increase the retry counter.
-                                retryService.increase(job);
                             }
 
-                            //Define the checkup status. 
-                            jobCheckupLog.setValue(value);
-                            jobCheckupLog.setSuccess(validated);
+                            //Identify if should revalidate the checkup.
+                            if (commandResult) {
+                                value = this.executeQuery(checkup);
+                                validated = this.check(checkup, value);
+                            }
 
-                            //Add the log to the checkup.
-                            checkup.addLog(jobCheckupLog);
-                            this.save(checkup);
+                        }
+
+                        //Define the checkup status. 
+                        jobCheckupLog.setValue(value);
+                        jobCheckupLog.setSuccess(validated);
+
+                        //Add the log to the checkup.
+                        checkup.addLog(jobCheckupLog);
+                        this.save(checkup);
+
+                        //Identify if should retry.
+                        if (retry <= job.getRetry() || (retry == 1 && job.getRetry() == 0)) {
 
                             //Identify if should execute an action.
                             if (!validated && !log) {
+                                //Increase the retry counter.
+                                retryService.increase(job);
                                 this.executeAction(job, checkup);
-                                retryService.remove(job);
-                                stop = true;
                             }
                         } else {
                             retryService.remove(job);
-                            stop = true;
                         }
 
                         //Verify if this check failed. 

--- a/src/main/java/br/com/dafiti/hanger/service/JobCheckupService.java
+++ b/src/main/java/br/com/dafiti/hanger/service/JobCheckupService.java
@@ -292,14 +292,14 @@ public class JobCheckupService {
         switch (checkup.getAction()) {
             case REBUILD:
                 try {
-                //Rebuild the job.
-                jobStatusService.updateFlow(job.getStatus(), Flow.REBUILD);
-                jenkinsService.build(job);
-            } catch (Exception ex) {
-                Logger.getLogger(EyeService.class.getName()).log(Level.SEVERE, "Fail building job: " + job.getName(), ex);
-            }
+                    //Rebuild the job.
+                    jobStatusService.updateFlow(job.getStatus(), Flow.REBUILD);
+                    jenkinsService.build(job);
+                } catch (Exception ex) {
+                    Logger.getLogger(EyeService.class.getName()).log(Level.SEVERE, "Fail building job: " + job.getName(), ex);
+                }
 
-            break;
+                break;
             case REBUILD_MESH:
                 HashSet<Job> parent = jobService.getMeshParent(job);
                 jobService.rebuildMesh(job);

--- a/src/main/java/br/com/dafiti/hanger/service/JobDetailsService.java
+++ b/src/main/java/br/com/dafiti/hanger/service/JobDetailsService.java
@@ -234,19 +234,21 @@ public class JobDetailsService {
             //Identifi if the job scope. 
             scope
                     .append(jobStatus.getScope().toString())
-                    .append(job.isAnyScope() ? " | FREE SCOPE ": "")
+                    .append(job.isAnyScope() ? " | FREE SCOPE " : "")
                     .append(job.isRebuild() ? " | REBUILD " + (job.isRebuildBlocked() ? "after all blockers ready " : "") + (job.getWait() != 0 ? "once every " + job.getWait() + " min" : "") : "")
                     .append((job.getTimeRestriction() == null || job.getTimeRestriction().isEmpty()) ? "" : " " + job.getTimeRestrictionDescription().toLowerCase());
 
             //Identify the number of build retries. 
             if (retryService.exists(job)
-                    && (job.getRetry() != 0)
-                    && (retryService.get(job) >= job.getRetry())) {
+                    && retryService.get(job) != 0
+                    && job.getRetry() != 0) {
 
                 building
-                        .append(" ( ")
+                        .append(" (")
+                        .append(retryService.get(job))
+                        .append(" of ")
                         .append(job.getRetry())
-                        .append("x )");
+                        .append(" tries)");
             }
         }
 

--- a/src/main/java/br/com/dafiti/hanger/service/RetryService.java
+++ b/src/main/java/br/com/dafiti/hanger/service/RetryService.java
@@ -76,13 +76,14 @@ public class RetryService {
      * @return Retry count
      */
     public int get(Job job) {
-        int value = 1;
+        int value = 0;
 
         if (retry.containsKey(job)) {
             value = retry.get(job);
         } else {
-            retry.put(job, 1);
+            retry.put(job, value);
         }
+        
         return value;
     }
 


### PR DESCRIPTION
Quando o checkup de um job possui uma ação diferente de "NOTHING" e "LOG_AND_CONTINUE" e a validação do healthcheck falha, o Retry configurado no job não é respeitado e a execução da ação entra em loop infinito ou só para quando a validação ocorre com sucesso.
Esse Pull Request visa corrigir esse bug basicamente ajustando na classe o momento de execução de cada parte do healthcheck (query de validação, comando e ação) para que a quantidade de retry seja respeitada.
O uso da variável "stop" foi removida por não ser necessário, e também foi reavalidado o momento para que a quantidade de tentativa fosse zerada novamente (retryService.remove(job);) para evitar o loop infinito.