### PR TITLE
DENG-704: Query retorna notação científica

### DIFF
--- a/src/main/java/br/com/dafiti/hanger/service/ConnectionService.java
+++ b/src/main/java/br/com/dafiti/hanger/service/ConnectionService.java
@@ -521,7 +521,7 @@ public class ConnectionService {
                 for (String column : queryResultSet.getHeader()) {
                     resultSetRow
                             .getColumn()
-                            .add(resultSet.getObject(column));
+                            .add(resultSet.getString(column));
                 }
 
                 //Sets the row to the resultset. 


### PR DESCRIPTION
Ajuste no resultado de uma _query_ no _Workbench_ que trazia em notação científica.